### PR TITLE
[security] Bump org.apache.httpcomponents:httpclient 4.3.4 -> 4.5.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.4</version>
+            <version>4.5.8</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>


### PR DESCRIPTION
This update resolves possible vulnerabilities reported in: CVE-2014-3577, CVE-2015-5262 
(minimum required update version is 4.3.6)