### PR TITLE
[security] Bump commons-fileupload:commons-fileupload 1.2 -> 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.2</version>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
This update resolves possible vulnerabilities reported in: CVE-2014-0050, CVE-2016-3092, CVE-2016-1000031
(minimum required update version is 1.3.3)
changes: https://commons.apache.org/proper/commons-fileupload/changes-report.html