### PR TITLE
send Cache-Control: must revalidate header, otherwise browsers cache stuff too long

### DIFF
--- a/src/main/java/nl/opengeogroep/safetymaps/server/stripes/VrhActionBean.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/stripes/VrhActionBean.java
@@ -137,6 +137,7 @@ public class VrhActionBean implements ActionBean {
                 if(lastModified != null) {
                     response.addDateHeader("Last-Modified", lastModified * 1000);
                 }
+                response.addHeader("Cache-Control", "must-revalidate");
 
                 OutputStream out;
                 String acceptEncoding = request.getHeader("Accept-Encoding");


### PR DESCRIPTION
Using Last-Modified causes browsers to use disk cache for a time depending on how long ago it was modified.

TODO: add for other responses which use Last-Modified.