### PR TITLE
Dev/set java api's to provided scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.1.1</version>
@@ -186,7 +192,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>3.0.1</version>
             <type>jar</type>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>


### PR DESCRIPTION
These JARs were included and conflict with the Tomcat classloader when using a javax.mail.Session JDNI resource.

Upgrades mvn dependency plugin so it works again.

diff van `mvn dependency:tree`:
```diff
18,20d17
< [INFO] |  |  \- javax:javaee-api:jar:7.0:compile
< [INFO] |  |     \- com.sun.mail:javax.mail:jar:1.5.0:compile
< [INFO] |  |        \- javax.activation:activation:jar:1.1:compile
30c27
< [INFO] +- javax.servlet:javax.servlet-api:jar:3.0.1:compile
---
> [INFO] +- javax.servlet:javax.servlet-api:jar:3.0.1:provided
36a34,36
> [INFO] +- javax:javaee-api:jar:7.0:provided
> [INFO] |  \- com.sun.mail:javax.mail:jar:1.5.0:provided
> [INFO] |     \- javax.activation:activation:jar:1.1:provided
```