### PR TITLE
set mod_auth_pubtkt cookie with SameSite=None, configurable name

### DIFF
--- a/src/main/java/nl/opengeogroep/safetymaps/security/ModAuthPubTktSSOFilter.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/security/ModAuthPubTktSSOFilter.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpSession;
 import nl.opengeogroep.safetymaps.server.db.Cfg;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import static nl.opengeogroep.safetymaps.utils.SameSiteCookieUtil.addCookieWithSameSite;
 
 /**
  * Generate ticket cookie for mod_auth_pubtkt (https://github.com/manuelkasper/mod_auth_pubtkt).
@@ -149,9 +150,9 @@ public class ModAuthPubTktSSOFilter implements Filter {
         cookie.setPath("/");
         cookie.setDomain(domain);
         cookie.setHttpOnly(true);
-        //cookie.setSecure(true); // don't set secure, for dev testing from http:// local URL
-        response.addCookie(cookie);
-        LOG.info("Added cookie with ticket for domain " + domain + " valid until " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(validUntil.getTime()));
+        cookie.setSecure(request.getScheme().equals("https"));
+        addCookieWithSameSite(response, cookie, "None");
+        LOG.info("Added cookie with ticket for domain " + domain + " (SameSite=None) valid until " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(validUntil.getTime()));
 
         request.getSession().setAttribute(SESSION_COOKIE_EXPIRY, cookieExpiry);
     }

--- a/src/main/java/nl/opengeogroep/safetymaps/utils/SameSiteCookieUtil.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/utils/SameSiteCookieUtil.java
@@ -1,0 +1,48 @@
+package nl.opengeogroep.safetymaps.utils;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ *
+ * @author matthijsln
+ */
+public class SameSiteCookieUtil {
+    public static void addCookieWithSameSite(HttpServletResponse response, Cookie cookie, String sameSite) {
+
+        OffsetDateTime expires = OffsetDateTime.now(ZoneOffset.UTC).plus(Duration.ofSeconds(cookie.getMaxAge()));
+        String cookieExpires = DateTimeFormatter.RFC_1123_DATE_TIME.format(expires);
+
+        String value = String.format("%s=%s; Max-Age=%d; Expires=%s; Path=%s",
+                cookie.getName(),
+                cookie.getValue(),
+                cookie.getMaxAge(),
+                cookieExpires,
+                cookie.getPath());
+
+        List attributes = new ArrayList();
+        if(cookie.getDomain() != null) {
+            attributes.add("Domain=" + cookie.getDomain());
+        }
+        if(cookie.isHttpOnly()) {
+            attributes.add("HttpOnly");
+        }
+        if(cookie.getSecure()) {
+            attributes.add("Secure");
+        }
+        if(sameSite != null) {
+            attributes.add("SameSite=" + sameSite);
+        }
+        if(!attributes.isEmpty()) {
+            value += "; " + String.join("; ", attributes);
+        }
+
+        response.addHeader("Set-Cookie", value);
+    }
+}


### PR DESCRIPTION
This allows a cookie for mod_auth_pubtkt set on demo.safetymaps.nl to be sent to demo-sproxy.safetymaps.nl with future browser restrictions.

Also allows name to be configured to keep different cookies apart.