### PR TITLE
Feature: Updatable login session roles

### DIFF
--- a/src/main/java/nl/opengeogroep/safetymaps/server/admin/stripes/EditGroupsActionBean.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/admin/stripes/EditGroupsActionBean.java
@@ -31,6 +31,7 @@ import static nl.opengeogroep.safetymaps.server.db.DB.USER_ADMIN;
 import static nl.opengeogroep.safetymaps.server.db.DB.USER_ROLE_TABLE;
 import static nl.opengeogroep.safetymaps.server.db.DB.USER_TABLE;
 import static nl.opengeogroep.safetymaps.server.db.DB.qr;
+import nl.opengeogroep.safetymaps.server.security.UpdatableLoginSessionFilter;
 import org.apache.commons.dbutils.handlers.ColumnListHandler;
 import org.apache.commons.dbutils.handlers.MapListHandler;
 import org.apache.commons.dbutils.handlers.ScalarHandler;
@@ -179,6 +180,8 @@ public class EditGroupsActionBean implements ActionBean, ValidationErrorHandler 
         log.info("Removing role " + role + ", deleted " + count + " user roles ");
         count = qr().update("delete from " + ROLE_TABLE + " where role = ?", role);
 
+        UpdatableLoginSessionFilter.updateAllSessionRoles();
+
         if(count != 0) {
             getContext().getMessages().add(new SimpleMessage("Groep is verwijderd"));
         } else {
@@ -206,6 +209,8 @@ public class EditGroupsActionBean implements ActionBean, ValidationErrorHandler 
         for(String u: users) {
             qr().update("insert into " + USER_ROLE_TABLE + "(username,role) values (?,?)", u, role);
         }
+
+        UpdatableLoginSessionFilter.updateAllSessionRoles();
 
         getContext().getMessages().add(new SimpleMessage("Groep is opgeslagen"));
         return new RedirectResolution(this.getClass()).flash(this);

--- a/src/main/java/nl/opengeogroep/safetymaps/server/db/DB.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/db/DB.java
@@ -35,7 +35,7 @@ public class DB {
     public static final String ROLE_EIGEN_VOERTUIGNUMMER = "eigen_voertuignummer";
     public static final String ROLE_DRAWING_EDITOR = "drawing_editor";
 
-    public static final String USERNAME_LDAP = "ldap_gebruiker";
+    public static final String USERNAME_LDAP = "LDAP";
 
     public static final DataSource getDataSource(String jndiName) throws NamingException {
         InitialContext cxt = new InitialContext();

--- a/src/main/java/nl/opengeogroep/safetymaps/server/security/ModAuthPubTkt.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/security/ModAuthPubTkt.java
@@ -1,4 +1,4 @@
-package nl.opengeogroep.safetymaps.security;
+package nl.opengeogroep.safetymaps.server.security;
 
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;

--- a/src/main/java/nl/opengeogroep/safetymaps/server/security/ModAuthPubTktSSOFilter.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/security/ModAuthPubTktSSOFilter.java
@@ -3,7 +3,7 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package nl.opengeogroep.safetymaps.security;
+package nl.opengeogroep.safetymaps.server.security;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/nl/opengeogroep/safetymaps/server/security/RoleProvider.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/security/RoleProvider.java
@@ -1,0 +1,18 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package nl.opengeogroep.safetymaps.server.security;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ *
+ * @author matthijsln
+ */
+public interface RoleProvider {
+    public Collection<String> getRoles(String username) throws Exception;
+    public Map<String, Collection<String>> getAllRolesByUsername() throws Exception;
+}

--- a/src/main/java/nl/opengeogroep/safetymaps/server/security/SafetyMapsRoleProvider.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/security/SafetyMapsRoleProvider.java
@@ -1,0 +1,49 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package nl.opengeogroep.safetymaps.server.security;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import nl.opengeogroep.safetymaps.server.db.DB;
+import static nl.opengeogroep.safetymaps.server.db.DB.qr;
+import org.apache.commons.dbutils.handlers.ColumnListHandler;
+import org.apache.commons.dbutils.handlers.MapListHandler;
+
+/**
+ *
+ * @author matthijsln
+ */
+public class SafetyMapsRoleProvider implements RoleProvider {
+
+    @Override
+    public Collection<String> getRoles(String username) throws Exception {
+
+        return qr().query("select role from " + DB.USER_ROLE_TABLE + " where username = ?", new ColumnListHandler<String>(), username);
+    }
+
+    @Override
+    public Map<String, Collection<String>> getAllRolesByUsername() throws Exception {
+
+        List<Map<String,Object>> rows = qr().query("select username, role from " + DB.USER_ROLE_TABLE, new MapListHandler());
+
+        Map<String,Collection<String>> rolesByUsername = new HashMap();
+
+        for(Map<String,Object> row: rows) {
+            String username = (String)row.get("username");
+            String role = (String)row.get("role");
+            Collection<String> roles = rolesByUsername.get(username);
+            if(roles == null) {
+                roles = new HashSet();
+                rolesByUsername.put(username, roles);
+            }
+            roles.add(role);
+        }
+        return rolesByUsername;
+    }
+}

--- a/src/main/java/nl/opengeogroep/safetymaps/server/security/SessionInvalidateMonitor.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/security/SessionInvalidateMonitor.java
@@ -1,0 +1,9 @@
+package nl.opengeogroep.safetymaps.server.security;
+
+/**
+ *
+ * @author matthijsln
+ */
+public interface SessionInvalidateMonitor {
+    public void invalidateUserSessions(String username);
+}

--- a/src/main/java/nl/opengeogroep/safetymaps/server/security/UpdatableLoginSessionFilter.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/security/UpdatableLoginSessionFilter.java
@@ -1,0 +1,290 @@
+package nl.opengeogroep.safetymaps.server.security;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Filter that keeps all container sessions and can invalidate them when an account
+ * is deleted, or update roles when role membership is updated.
+ *
+ * Supports getting role membership based on a fixed role set by external logins
+ * using that role as the username. For instance a LDAPUser role will cause roles
+ * that the user with name LDAPUser is a member of to be added to the login
+ * session.
+ *
+ * Role membership data by username is provided by an external class configured
+ * by class name.
+ *
+ * Note that only those roles provided by the role provider and original roles for
+ * which group membership as a username was checked will return true for chained
+ * request.isUserInRole() calls, other roles the original request.isUserInRole()
+ * would return true for are dropped. These original roles would not be re-checked
+ * for the duration of the session, and that would be inconsistent with the purpose
+ * of this filter.
+ *
+ * @author matthijsln
+ */
+public class UpdatableLoginSessionFilter implements Filter {
+
+    private static final Log log = LogFactory.getLog(UpdatableLoginSessionFilter.class);
+
+    private static String[] externalRoleNamesForGroupMembership = new String[] {};
+
+    private static RoleProvider roleProvider;
+
+    private static final ConcurrentMap<String,HttpSession> CONTAINER_SESSIONS = new ConcurrentHashMap();
+
+    private static final String SESSION_ATTR_ROLES = UpdatableLoginSessionFilter.class.getName() + ".ROLES";
+    private static final String SESSION_ATTR_USERNAME = UpdatableLoginSessionFilter.class.getName() + ".USERNAME";
+
+    private static final Collection<SessionInvalidateMonitor> sessionInvalidateMonitors = new ArrayList();
+
+    private static long lastInactiveSessionsPruned;
+
+    private static final long INACTIVE_SESSIONS_PRUNE_INTERVAL = 10 * 60 * 1000;
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+
+        String s = filterConfig.getInitParameter("externalRolesForGroupMembership");
+
+        if(s != null) {
+            externalRoleNamesForGroupMembership = s.split(",");
+        }
+
+        String providerClass = filterConfig.getInitParameter("roleProviderClass");
+        if(providerClass != null) {
+            try {
+                roleProvider = (RoleProvider)Class.forName(providerClass).newInstance();
+            } catch(Exception e) {
+                log.error("Cannot instantiate role provider class " + providerClass, e);
+            }
+        }
+
+        lastInactiveSessionsPruned = System.currentTimeMillis();
+    }
+
+    private void pruneInactiveSessions() {
+        long current = System.currentTimeMillis();
+
+        if(current - lastInactiveSessionsPruned > INACTIVE_SESSIONS_PRUNE_INTERVAL) {
+            lastInactiveSessionsPruned = current;
+
+            synchronized(CONTAINER_SESSIONS) {
+                List<String> sessionIdsToRemove = new ArrayList();
+                for(Map.Entry<String,HttpSession> entry: CONTAINER_SESSIONS.entrySet()) {
+                    HttpSession session = entry.getValue();
+                    if(current - session.getLastAccessedTime() > session.getMaxInactiveInterval() * 1000) {
+                        sessionIdsToRemove.add(entry.getKey());
+                    }
+                }
+                if(!sessionIdsToRemove.isEmpty()) {
+                    for(String id: sessionIdsToRemove) {
+                        CONTAINER_SESSIONS.remove(id);
+                    }
+                    log.debug("Pruned " + sessionIdsToRemove + " inactive sessions");
+                }
+            }
+
+        }
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain) throws IOException, ServletException {
+
+        HttpServletRequest request = (HttpServletRequest)servletRequest;
+        HttpServletResponse response = (HttpServletResponse)servletResponse;
+        HttpSession session = request.getSession();
+
+        pruneInactiveSessions();
+
+        // Save the session, so it can be invalidated when the user account is
+        // deleted
+
+        CONTAINER_SESSIONS.putIfAbsent(session.getId(), session);
+
+        if(roleProvider == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // Check if we already processed the session the first time it was authenticated
+
+        Collection<String> roles = (Collection<String>)session.getAttribute(SESSION_ATTR_ROLES);
+
+        if(roles != null) {
+            chainWithRoles(request, response, chain, roles);
+            return;
+        }
+
+        // If not authenticated, pass through
+
+        if(request.getUserPrincipal() == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // User is authenticated, get roles from provider and save them in the
+        // session, so they can be updated when membership changes
+
+        try {
+            roles = new HashSet(roleProvider.getRoles(request.getRemoteUser()));
+
+            for(String role: externalRoleNamesForGroupMembership) {
+                if(request.isUserInRole(role)) {
+                    roles.addAll(roleProvider.getRoles(role));
+                    // Make sure when updating role membership, we can check wether
+                    // the user was in this role again
+                    roles.add(role);
+                }
+            }
+
+            session.setAttribute(SESSION_ATTR_USERNAME, request.getRemoteUser());
+            session.setAttribute(SESSION_ATTR_ROLES, roles);
+
+            chainWithRoles(request, response, chain, roles);
+        } catch(Exception e) {
+            throw new ServletException(e);
+        }
+    }
+
+    private static void chainWithRoles(final HttpServletRequest request, HttpServletResponse response, FilterChain chain, final Collection<String> roles) throws IOException, ServletException {
+        chain.doFilter(new HttpServletRequestWrapper(request) {
+            @Override
+            public boolean isUserInRole(String role) {
+                return roles.contains(role);
+            }
+        }, response);
+    }
+
+    public static void invalidateUserSessions(String name) throws IOException {
+        List<String> invalidSessionIds = new ArrayList<>();
+        for(HttpSession session: CONTAINER_SESSIONS.values()) {
+            try {
+                String sessionUser = (String)session.getAttribute(SESSION_ATTR_USERNAME);
+                log.debug("Checking container session " + session.getId() + " to delete, session user = " + sessionUser);
+                if(name.equals(sessionUser)) {
+                    log.info("Invalidating container session for user " + name + ": " + session.getId());
+                    session.invalidate();
+                    invalidSessionIds.add(session.getId());
+                }
+            } catch(IllegalStateException e) {
+                log.info("Session already invalid: " + session.getId());
+                invalidSessionIds.add(session.getId());
+            }
+        }
+        for(String id: invalidSessionIds) {
+            CONTAINER_SESSIONS.remove(id);
+        }
+
+        for(SessionInvalidateMonitor monitor: sessionInvalidateMonitors) {
+            monitor.invalidateUserSessions(name);
+        }
+    }
+
+    public static void monitorSessionInvalidation(SessionInvalidateMonitor monitor) {
+        sessionInvalidateMonitors.add(monitor);
+    }
+
+    public static void updateUserSessionRoles(String username) throws Exception {
+        if(roleProvider == null) {
+            return;
+        }
+
+        synchronized(CONTAINER_SESSIONS) {
+
+            for(HttpSession session: CONTAINER_SESSIONS.values()) {
+                try {
+                    String sessionUsername = (String)session.getAttribute(SESSION_ATTR_USERNAME);
+
+                    if(sessionUsername != null) {
+                        boolean needsUpdate = sessionUsername.equals(username);
+
+                        Collection<String> previousRoles = (Collection<String>)session.getAttribute(SESSION_ATTR_ROLES);
+
+                        // Also update session when updating roles of user that is used
+                        // for role membership by setting a role in the original request
+
+                        for(String role: externalRoleNamesForGroupMembership) {
+                            if(role.equals(username) && previousRoles.contains(role)) {
+                                needsUpdate = true;
+                            }
+                        }
+
+                        if(needsUpdate) {
+                            Collection<String> newRoles = new HashSet();
+
+                            newRoles.addAll(roleProvider.getRoles(username));
+
+                            for(String role: externalRoleNamesForGroupMembership) {
+                                if(previousRoles.contains(role)) {
+                                    newRoles.addAll(roleProvider.getRoles(role));
+                                    newRoles.add(role);
+                                }
+                            }
+                            session.setAttribute(SESSION_ATTR_ROLES, newRoles);
+                        }
+                    }
+                } catch(IllegalStateException e) {
+                    // Session was invalid
+                }
+            }
+        }
+    }
+
+    public static void updateAllSessionRoles() throws Exception {
+        if(roleProvider == null) {
+            return;
+        }
+
+        synchronized(CONTAINER_SESSIONS) {
+            Map<String, Collection<String>> rolesByUsername = roleProvider.getAllRolesByUsername();
+
+            for(HttpSession session: CONTAINER_SESSIONS.values()) {
+                try {
+                    String username = (String)session.getAttribute(SESSION_ATTR_USERNAME);
+
+                    if(username != null) {
+                        Collection<String> previousRoles = (Collection<String>)session.getAttribute(SESSION_ATTR_ROLES);
+                        Collection<String> newRoles = new HashSet();
+
+                        newRoles.addAll(rolesByUsername.get(username));
+
+                        for(String role: externalRoleNamesForGroupMembership) {
+                            if(previousRoles.contains(role)) {
+                                newRoles.addAll(rolesByUsername.get(role));
+                                newRoles.add(role);
+                            }
+                        }
+                        session.setAttribute(SESSION_ATTR_ROLES, newRoles);
+                    }
+                } catch(IllegalStateException e) {
+                    // Session was invalid
+                }
+            }
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/src/main/java/nl/opengeogroep/safetymaps/server/security/UpdatableLoginSessionFilter.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/security/UpdatableLoginSessionFilter.java
@@ -92,7 +92,12 @@ public class UpdatableLoginSessionFilter implements Filter {
                 List<String> sessionIdsToRemove = new ArrayList();
                 for(Map.Entry<String,HttpSession> entry: CONTAINER_SESSIONS.entrySet()) {
                     HttpSession session = entry.getValue();
-                    if(current - session.getLastAccessedTime() > session.getMaxInactiveInterval() * 1000) {
+                    try {
+                        if(current - session.getLastAccessedTime() > session.getMaxInactiveInterval() * 1000) {
+                            sessionIdsToRemove.add(entry.getKey());
+                        }
+                    } catch(IllegalStateException e) {
+                        // Session already invalidated
                         sessionIdsToRemove.add(entry.getKey());
                     }
                 }

--- a/src/main/java/nl/opengeogroep/safetymaps/server/security/UpdatableLoginSessionFilter.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/security/UpdatableLoginSessionFilter.java
@@ -261,9 +261,9 @@ public class UpdatableLoginSessionFilter implements Filter {
             return;
         }
 
-        synchronized(CONTAINER_SESSIONS) {
-            Map<String, Collection<String>> rolesByUsername = roleProvider.getAllRolesByUsername();
+        Map<String, Collection<String>> rolesByUsername = roleProvider.getAllRolesByUsername();
 
+        synchronized(CONTAINER_SESSIONS) {
             for(HttpSession session: CONTAINER_SESSIONS.values()) {
                 try {
                     String username = (String)session.getAttribute(SESSION_ATTR_USERNAME);

--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -46,7 +46,7 @@
             userBase="o=MyOrg"
             userSubtree="true"
             userSearch="cn={0}"
-            commonRole="ExtendedUser"
+            commonRole="LDAP"
         /-->
   </Realm>
 </Context>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -99,7 +99,7 @@
     <filter>
         <display-name>mod_auth_pubtkt SSO filter</display-name>
         <filter-name>ModAuthPubTktSSOFilter</filter-name>
-        <filter-class>nl.opengeogroep.safetymaps.security.ModAuthPubTktSSOFilter</filter-class>
+        <filter-class>nl.opengeogroep.safetymaps.server.security.ModAuthPubTktSSOFilter</filter-class>
         <!-- enabled/disabled by safetymaps.settings database config -->
     </filter>
     <filter>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -22,19 +22,6 @@
         <param-value>nl</param-value>
     </context-param>
     <filter>
-        <description>Persistent logins across browser sessions</description>
-        <filter-name>PersistentAuthenticationFilter</filter-name>
-        <filter-class>nl.opengeogroep.safetymaps.server.security.PersistentAuthenticationFilter</filter-class>
-        <init-param>
-            <param-name>enabled</param-name>
-            <param-value>true</param-value>
-        </init-param>
-        <init-param>
-            <param-name>persistentLoginPathPrefix</param-name>
-            <param-value>/viewer/api/</param-value>
-        </init-param>
-    </filter>
-    <filter>
         <description>Filter from Tomcat 6 distribution, see http://wiki.apache.org/tomcat/FAQ/CharacterEncoding</description>
         <filter-name>SetCharacterEncodingFilter</filter-name>
         <filter-class>nl.b3p.web.filter.SetCharacterEncodingFilter</filter-class>
@@ -89,11 +76,41 @@
         <filter-class>nl.opengeogroep.safetymaps.server.security.MellonHeaderAuthenticationFilter</filter-class>
         <init-param>
             <param-name>commonRole</param-name>
-            <param-value>SAMLUser</param-value>
+            <param-value>SAML</param-value>
         </init-param>
         <init-param>
             <param-name>saveExtraHeaders</param-name>
             <param-value>_SESSION</param-value>
+        </init-param>
+    </filter>
+    <filter>
+        <description>Persistent logins across browser sessions</description>
+        <filter-name>PersistentAuthenticationFilter</filter-name>
+        <filter-class>nl.opengeogroep.safetymaps.server.security.PersistentAuthenticationFilter</filter-class>
+        <init-param>
+            <param-name>enabled</param-name>
+            <param-value>true</param-value>
+        </init-param>
+        <init-param>
+            <param-name>persistentLoginPathPrefix</param-name>
+            <param-value>/viewer/api/</param-value>
+        </init-param>
+        <init-param>
+            <param-name>rolesAsDbUsernames</param-name>
+            <param-value>LDAP</param-value>
+        </init-param>
+    </filter>
+    <filter>
+        <description>Updatable roles and invalidatable login sessions</description>
+        <filter-name>UpdatableLoginSessionFilter</filter-name>
+        <filter-class>nl.opengeogroep.safetymaps.server.security.UpdatableLoginSessionFilter</filter-class>
+        <init-param>
+            <param-name>externalRolesForGroupMembership</param-name>
+            <param-value>LDAP,SAML</param-value>
+        </init-param>
+        <init-param>
+            <param-name>roleProviderClass</param-name>
+            <param-value>nl.opengeogroep.safetymaps.server.security.SafetyMapsRoleProvider</param-value>
         </init-param>
     </filter>
     <filter>
@@ -121,6 +138,10 @@
     </filter-mapping>
     <filter-mapping>
         <filter-name>PersistentAuthenticationFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>UpdatableLoginSessionFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <filter-mapping>


### PR DESCRIPTION
Alternative to #33 

Moves registry of active sessions and list of roles to a separate filter: `UpdatableLoginSessionFilter`.

Simplifies the `PersistentAuthenticationFilter` and `MellonHeaderAuthenticationFilter` by moving the logic of getting roles by using an external role as a SafetyMaps username to the  `UpdatableLoginSessionFilter`.

The persistent session filter restores role membership in saved loginSource when external, so roles for sessions for LDAP authenticated users also get updated.

When a user is edited, the roles for all actives sessions for that users are refreshed. When a user is deleted, all sessions are ended.

When a group is edited, all roles for all sessions are refreshed.