### PR TITLE
Remove CORS headers from MailActionBean because CorsFilter add CORS headers

### DIFF
--- a/src/main/java/nl/opengeogroep/safetymaps/server/stripes/MailActionBean.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/stripes/MailActionBean.java
@@ -46,8 +46,6 @@ public class MailActionBean implements ActionBean {
     public Resolution mail() throws IOException {
         Session session;
         JSONObject response = new JSONObject();
-        context.getResponse().addHeader("Access-Control-Allow-Origin", "http://localhost");
-        context.getResponse().addHeader("Access-Control-Allow-Credentials", "true");
         response.put("result", false);
         try {
             Context ctx = new InitialContext();


### PR DESCRIPTION
Multiple same CORS headers results in a CORS header error on the clients.