### PR TITLE
Use secure password storage with backward compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,12 @@
             <version>1.3.1</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <version>9.0.48</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     
     <repositories>

--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -34,8 +34,24 @@
   <!-- Security configuration -->
   <!-- use LockOutRealm instead of CombinedRealm to prevent brute-forcing -->
   <Realm className="org.apache.catalina.realm.LockOutRealm">
-    <Realm allRolesMode="authOnly" className="org.apache.catalina.realm.DataSourceRealm" dataSourceName="jdbc/safetymaps-server" digest="SHA-1" roleNameCol="role" userCredCol="password" userNameCol="username" userRoleTable="safetymaps.user_roles" userTable="safetymaps.user_">
-      <CredentialHandler algorithm="SHA-1" className="org.apache.catalina.realm.MessageDigestCredentialHandler"/>
+    <Realm allRolesMode="authOnly" className="org.apache.catalina.realm.DataSourceRealm" dataSourceName="jdbc/safetymaps-server" roleNameCol="role" userCredCol="password" userNameCol="username" userRoleTable="safetymaps.user_roles" userTable="safetymaps.user_">
+      <CredentialHandler className="org.apache.catalina.realm.NestedCredentialHandler">
+        <!-- When these attributes are changed, also modify them in EditUsersActionBean!
+             To generate a password from the commandline, execute:
+             apache-tomcat/bin/digest.sh -a PBKDF2WithHmacSHA512 -i 100000 -s 16 -k 256 -h "org.apache.catalina.realm.SecretKeyCredentialHandler" mypassword
+        -->
+        <CredentialHandler className="org.apache.catalina.realm.SecretKeyCredentialHandler"
+                           algorithm="PBKDF2WithHmacSHA512"
+                           iterations="100000"
+                           keyLength="256"
+                           saltLength="16"
+        />
+        <CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler"
+                           algorithm="SHA-1"
+                           iterations="1"
+                           saltLength="0"
+        />
+      </CredentialHandler>
     </Realm>
     <!-- Use JNDIRealm for authenticating against a LDAP server (such as
              Active Directory):

--- a/src/main/webapp/WEB-INF/jsp/admin/editUsers.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/editUsers.jsp
@@ -26,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <thead>
                 <tr>
                     <th>Gebruikersnaam</th>
+                    <th></th>
                     <th>Afkomstig uit</th>
                     <th>Aantal voertuigviewer sessies</th>
                     <th>Laatst ingelogd op</th>
@@ -41,7 +42,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <c:set var="editLink" value=""/>
                 </c:if>
                 <tr style="${editLink == '' ? '' : 'cursor: pointer'}" class="${actionBean.username == u.username ? 'info' : ''}" onclick="${editLink != '' ? 'window.location.href=\''.concat(editLink).concat('\'') : ''}">
-                    <td><c:out value="${u.username}"/></td>
+                    <td><c:out value="${u.username}"/> </td>
+                    <td>
+                        <c:choose>
+                            <c:when test="${u.secure_password == null}"></c:when>
+                            <c:when test="${u.secure_password}">
+                                <span style="color: green">Wachtwoord veilig opgeslagen</span>
+                            </c:when>
+                            <c:otherwise>
+                                <span style="color: red" title="Het wachtwoord is met een onveilig hash-algoritme (SHA-1) opgeslagen. Wijzig het wachtwoord zodat deze veiliger wordt opgeslagen (PBKDF2WithHmacSHA512 met salt en 100.000 iteraties)">Wachtwoord update nodig!</span>
+                            </c:otherwise>
+                        </c:choose>
+                    </td>
                     <td><c:out value="${u.login_source}"/></td>
                     <td><c:out value="${u.session_count}"/></td>
                     <td><c:out value="${u.last_login}"/></td>


### PR DESCRIPTION
Upgrade van SHA-1 naar PBKDF2WithHmacSHA512 met salt en 100.000 iteraties. Door gebruik van de `NestedCredentialHandler` worden oude SHA-1 hashes ook nog ondersteund.

Let op, alle context.xmls in overlays moeten worden aangepast!

Als een account nog een SHA1 hash gebruikt wordt dit in de gebruikerspagina in het rood weergegeven, zodat de beheerder weet dat het wachtwoord gewijzigd moet worden.