### PR TITLE
External authorization improvements

### DIFF
--- a/src/main/java/nl/opengeogroep/safetymaps/server/security/MellonHeaderAuthenticationFilter.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/security/MellonHeaderAuthenticationFilter.java
@@ -373,7 +373,7 @@ public class MellonHeaderAuthenticationFilter implements Filter {
         return (Map<String, String>)request.getSession().getAttribute(ATTR_EXTRA_HEADERS);
     }
 
-    private class HeaderAuthenticatedPrincipal implements Principal {
+    public static class HeaderAuthenticatedPrincipal implements Principal {
         private final String name;
         private final Set<String> roles;
 

--- a/src/main/java/nl/opengeogroep/safetymaps/server/security/RoleProvider.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/security/RoleProvider.java
@@ -13,6 +13,6 @@ import java.util.Map;
  * @author matthijsln
  */
 public interface RoleProvider {
-    public Collection<String> getRoles(String username) throws Exception;
-    public Map<String, Collection<String>> getAllRolesByUsername() throws Exception;
+    public Collection<String> getRoles(String username);
+    public Map<String, Collection<String>> getAllRolesByUsername();
 }

--- a/src/main/java/nl/opengeogroep/safetymaps/server/security/SafetyMapsRoleProvider.java
+++ b/src/main/java/nl/opengeogroep/safetymaps/server/security/SafetyMapsRoleProvider.java
@@ -5,15 +5,17 @@
  */
 package nl.opengeogroep.safetymaps.server.security;
 
+import nl.opengeogroep.safetymaps.server.db.DB;
+import org.apache.commons.dbutils.handlers.ColumnListHandler;
+import org.apache.commons.dbutils.handlers.MapListHandler;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import nl.opengeogroep.safetymaps.server.db.DB;
+
 import static nl.opengeogroep.safetymaps.server.db.DB.qr;
-import org.apache.commons.dbutils.handlers.ColumnListHandler;
-import org.apache.commons.dbutils.handlers.MapListHandler;
 
 /**
  *
@@ -22,28 +24,34 @@ import org.apache.commons.dbutils.handlers.MapListHandler;
 public class SafetyMapsRoleProvider implements RoleProvider {
 
     @Override
-    public Collection<String> getRoles(String username) throws Exception {
-
-        return qr().query("select role from " + DB.USER_ROLE_TABLE + " where username = ?", new ColumnListHandler<String>(), username);
+    public Collection<String> getRoles(String username) {
+        try {
+            return qr().query("select role from " + DB.USER_ROLE_TABLE + " where username = ?", new ColumnListHandler<String>(), username);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
-    public Map<String, Collection<String>> getAllRolesByUsername() throws Exception {
+    public Map<String, Collection<String>> getAllRolesByUsername() {
+        try {
+            List<Map<String,Object>> rows = qr().query("select username, role from " + DB.USER_ROLE_TABLE, new MapListHandler());
 
-        List<Map<String,Object>> rows = qr().query("select username, role from " + DB.USER_ROLE_TABLE, new MapListHandler());
+            Map<String,Collection<String>> rolesByUsername = new HashMap();
 
-        Map<String,Collection<String>> rolesByUsername = new HashMap();
-
-        for(Map<String,Object> row: rows) {
-            String username = (String)row.get("username");
-            String role = (String)row.get("role");
-            Collection<String> roles = rolesByUsername.get(username);
-            if(roles == null) {
-                roles = new HashSet();
-                rolesByUsername.put(username, roles);
+            for(Map<String,Object> row: rows) {
+                String username = (String)row.get("username");
+                String role = (String)row.get("role");
+                Collection<String> roles = rolesByUsername.get(username);
+                if(roles == null) {
+                    roles = new HashSet();
+                    rolesByUsername.put(username, roles);
+                }
+                roles.add(role);
             }
-            roles.add(role);
+            return rolesByUsername;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
-        return rolesByUsername;
     }
 }


### PR DESCRIPTION
- /authinfo.jsp shows role list
- External role names from LDAP/SAML to be used as username to get group membership can be configured in safetymaps.settings instead of filter init parameter
